### PR TITLE
Upgrade Spectre.Console to v0.45

### DIFF
--- a/UniqueFileGenerator/UniqueFileGenerator.csproj
+++ b/UniqueFileGenerator/UniqueFileGenerator.csproj
@@ -8,7 +8,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.43.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">


### PR DESCRIPTION
Upgrade to the [Spectre.Console package](https://www.nuget.org/packages/Spectre.Console/) to version 0.45 from 0.43.